### PR TITLE
Fix void-function when ox-md isn't loaded

### DIFF
--- a/ox-tufte.el
+++ b/ox-tufte.el
@@ -33,7 +33,7 @@
 ;;; Code:
 
 (require 'ox)
-
+(require 'ox-md)
 
 ;;; User-Configurable Variables
 


### PR DESCRIPTION
Fixes #1 